### PR TITLE
fix wrong property name

### DIFF
--- a/src/config/phpsms.php
+++ b/src/config/phpsms.php
@@ -90,6 +90,9 @@ return [
             //REST版本号，在官网文档REST介绍中获得。
             'softVersion' => '2013-12-26',
 
+            //包体格式，可填值：json 、xml
+            'bodyType' => 'xml',
+
             //语音验证码使用的语言类型
             'voiceLang' => 'zh',
 

--- a/src/phpsms/agents/YunTongXunAgent.php
+++ b/src/phpsms/agents/YunTongXunAgent.php
@@ -10,6 +10,7 @@ use REST;
  * @property string $serverIP
  * @property string $serverPort
  * @property string $softVersion
+ * @property string $bodyType
  * @property string $accountSid
  * @property string $accountToken
  * @property string $appId
@@ -29,7 +30,8 @@ class YunTongXunAgent extends Agent
         $rest = new REST(
             $this->serverIP,
             $this->serverPort,
-            $this->softVersion
+            $this->softVersion,
+            $this->bodyType
         );
         $rest->setAccount($this->accountSid, $this->accountToken);
         $rest->setAppId($this->appId);
@@ -59,7 +61,8 @@ class YunTongXunAgent extends Agent
         $rest = new REST(
             $this->serverIP,
             $this->serverPort,
-            $this->softVersion
+            $this->softVersion,
+            $this->bodyType
         );
         $rest->setAccount($this->accountSid, $this->accountToken);
         $rest->setAppId($this->appId);

--- a/src/phpsms/agents/YunTongXunAgent.php
+++ b/src/phpsms/agents/YunTongXunAgent.php
@@ -41,7 +41,7 @@ class YunTongXunAgent extends Agent
             if ($code === '000000') {
                 $this->result['success'] = true;
                 $this->result['code'] = $code;
-                $this->result['info'] = 'smsSid:' . $result->TemplateSms->smsMessageSid;
+                $this->result['info'] = 'smsSid:' . $result->templateSMS->smsMessageSid;
             } else {
                 $this->result['code'] = $code;
                 $this->result['info'] = (string) $result->statusMsg;

--- a/src/phpsms/lib/CCPRestSmsSDK.php
+++ b/src/phpsms/lib/CCPRestSmsSDK.php
@@ -24,12 +24,15 @@ class REST
     private $Batch;  //时间戳
     private $BodyType = 'xml'; //包体格式，可填值：json 、xml
 
-    public function __construct($ServerIP, $ServerPort, $SoftVersion)
+    public function __construct($ServerIP, $ServerPort, $SoftVersion, $BodyType = 'xml')
     {
         $this->Batch = date('YmdHis');
         $this->ServerIP = $ServerIP;
         $this->ServerPort = $ServerPort;
         $this->SoftVersion = $SoftVersion;
+        if (in_array($BodyType, ['xml', 'json'])) {
+            $this->BodyType = $BodyType;
+        }
     }
 
     /**


### PR DESCRIPTION
Got PHP error:  Undefined property: stdClass::$TemplateSms in /var/www/vendor/toplan/phpsms/src/phpsms/agents/YunTongXunAgent.php on line 44

when var_dump $result, got 
object(stdClass)#710 (2) {
  ["templateSMS"]=>
  object(stdClass)#704 (2) {
    ["smsMessageSid"]=>
    string(32) "6b79ce4137c949518f2eb4c47e4d4628"
    ["dateCreated"]=>
    string(14) "20160402104047"
  }
  ["statusCode"]=>
  string(6) "000000"
}